### PR TITLE
Add *essential* stalled / ending-too-soon debugging utilities.

### DIFF
--- a/files/tests/test-helper.ts
+++ b/files/tests/test-helper.ts
@@ -1,9 +1,29 @@
 import Application from '<%= modulePrefix %>/app';
 import config from '<%= modulePrefix %>/config/environment';
 import * as QUnit from 'qunit';
-import { setApplication } from '@ember/test-helpers';
+import { setApplication, getSettledState, currentUrl, currentRouteName } from '@ember/test-helpers';
+import { getPendingWaiterState } from '@ember/test-waiters';
 import { setup } from 'qunit-dom';
 import { start as qunitStart, setupEmberOnerrorValidation } from 'ember-qunit';
+
+Object.assign(window, {
+  getSettledState,
+  getPendingWaiterState,
+  currentURL,
+  currentRouteName,
+  snapshotTimers: (label?: string) => {
+    const result = JSON.parse(
+      JSON.stringify({
+        settled: getSettledState(),
+        waiters: getPendingWaiterState(),
+      })
+    );
+
+    console.debug(label ?? 'snapshotTimers', result);
+
+    return result;
+  },
+});
 
 export function start() {
   setApplication(Application.create(config.APP));


### PR DESCRIPTION
These utilities are _essential_ for debugging anything related to:
- stuck tests
- tests progressing too soon
- mismatched URLs
- etc

Specifically, snapshotTimers is good because it serializer the waiter information so it doesn't change out from underneath if you if you were to just do `getPendingWaiterState()` and log that out.