### PR TITLE
Fix NODE_ENV for tests

### DIFF
--- a/files/.env.test
+++ b/files/.env.test
@@ -1,2 +1,8 @@
+# This file is committed to git and should not contain any secrets.
+# 
+# Vite recommends using .env.local or .env.[mode].local if you need to manage secrets
+# SEE: https://vite.dev/guide/env-and-mode.html#env-files for more information.
+
+
 # Default NODE_ENV with vite build --mode=test is production
 NODE_ENV=development

--- a/files/.env.test
+++ b/files/.env.test
@@ -1,0 +1,2 @@
+# Default NODE_ENV with vite build --mode=test is production
+NODE_ENV=development

--- a/files/package.json
+++ b/files/package.json
@@ -25,7 +25,7 @@
     "lint:types": "glint<% } %>",
     "start": "vite",
     "test": "concurrently \"<%= packageManager %>:lint\" \"<%= packageManager %>:test:*\" --names \"lint,test:\" --prefixColors auto",
-    "test:ember": "vite build --mode test && testem ci"
+    "test:ember": "NODE_ENV=development vite build --mode test && testem ci"
   },
   "exports": {
     "./tests/*": "./tests/*",

--- a/files/package.json
+++ b/files/package.json
@@ -25,7 +25,7 @@
     "lint:types": "glint<% } %>",
     "start": "vite",
     "test": "concurrently \"<%= packageManager %>:lint\" \"<%= packageManager %>:test:*\" --names \"lint,test:\" --prefixColors auto",
-    "test:ember": "NODE_ENV=development vite build --mode test && testem ci"
+    "test:ember": "vite build --mode test && testem ci"
   },
   "exports": {
     "./tests/*": "./tests/*",


### PR DESCRIPTION
See also: https://github.com/embroider-build/embroider/pull/2501 for additional context


(Thanks @Robbytx)


Without this change, debug things like `assert`, `warn`, `deprecate`, etc are all stripped from testing -- which we don't want out of the box.