### PR TITLE
Adjust the lint command / enforce prettier in CI (our code, not for the output)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 files/
 node_modules/
 tests/fixture/
+tests/fixture-ts/
 
 *.yml
 *.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+files/
+node_modules/
+tests/fixture/
+
+*.yml
+*.yaml
+*.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,10 @@ export default [
   pluginJs.configs.recommended,
   eslintConfigPrettier,
   {
-    ignores: ['tests/fixture/*', 'tests/fixture-ts/*', 'files/ember-cli-build.js'],
+    ignores: [
+      'tests/fixture/*',
+      'tests/fixture-ts/*',
+      'files/ember-cli-build.js',
+    ],
   },
 ];

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ module.exports = {
     let name = stringUtil.dasherize(rawName);
     let namespace = stringUtil.classify(rawName);
 
-    let hasOptions = !options.welcome || options.packageManager || options.ciProvider;
+    let hasOptions =
+      !options.welcome || options.packageManager || options.ciProvider;
     let blueprintOptions = '';
     if (hasOptions) {
       let indent = `\n            `;
@@ -66,7 +67,8 @@ module.exports = {
       blueprintVersion: require('./package').version,
       yarn: options.packageManager === 'yarn',
       pnpm: options.packageManager === 'pnpm',
-      npm: options.packageManager !== 'yarn' && options.packageManager !== 'pnpm',
+      npm:
+        options.packageManager !== 'yarn' && options.packageManager !== 'pnpm',
       invokeScriptPrefix,
       execBinPrefix,
       welcome: options.welcome,
@@ -93,7 +95,9 @@ module.exports = {
 
     if (!options.typescript) {
       files = files.filter(
-        (file) => !['tsconfig.json', 'app/config/', 'types/'].includes(file) && !file.endsWith('.d.ts')
+        (file) =>
+          !['tsconfig.json', 'app/config/', 'types/'].includes(file) &&
+          !file.endsWith('.d.ts'),
       );
     }
 
@@ -110,7 +114,12 @@ module.exports = {
   beforeInstall() {
     const prependEmoji = require('./lib/prepend-emoji');
 
-    this.ui.writeLine(prependEmoji('✨', `Creating a new Ember app in ${chalk.yellow(process.cwd())}:`));
+    this.ui.writeLine(
+      prependEmoji(
+        '✨',
+        `Creating a new Ember app in ${chalk.yellow(process.cwd())}:`,
+      ),
+    );
   },
 
   /**

--- a/lib/prepend-emoji.js
+++ b/lib/prepend-emoji.js
@@ -2,7 +2,9 @@
 
 function supportEmoji() {
   const hasEmojiTurnedOff = process.argv.indexOf('--no-emoji') > -1;
-  return process.stdout.isTTY && process.platform !== 'win32' && !hasEmojiTurnedOff;
+  return (
+    process.stdout.isTTY && process.platform !== 'win32' && !hasEmojiTurnedOff
+  );
 }
 
 const areEmojiSupported = supportEmoji();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   "author": "",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "concurrently 'pnpm:lint:*'",
+    "lint:eslint": "eslint .",
+    "lint:prettier": "prettier . --check",
+    "format": "prettier . --write",
     "test": "vitest"
   },
   "dependencies": {
@@ -24,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.3.0",
+    "concurrently": "^9.1.2",
     "ember-cli": "^6.3.1",
     "eslint": "9.x",
     "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "main": "index.js",
   "scripts": {
-    "lint": "concurrently 'pnpm:lint:*'",
+    "lint": "concurrently 'pnpm:lint:*(!fix)'",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier . --check",
     "format": "prettier . --write",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "concurrently 'pnpm:lint:*(!fix)'",
+    "lint:fix": "pnpm lint:eslint && pnpm format",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier . --check",
     "format": "prettier . --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^9.3.0
         version: 9.25.1
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
       ember-cli:
         specifier: ^6.3.1
         version: 6.3.1(handlebars@4.7.8)(underscore@1.13.7)
@@ -1264,6 +1267,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.1.2:
+    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -3501,6 +3509,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
 
@@ -3718,6 +3730,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3828,6 +3844,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   tree-sync@1.4.0:
     resolution: {integrity: sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==}
@@ -5541,6 +5561,16 @@ snapshots:
       - supports-color
 
   concat-map@0.0.1: {}
+
+  concurrently@9.1.2:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   config-chain@1.1.13:
     dependencies:
@@ -7961,6 +7991,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
   shellwords@0.1.1: {}
 
   side-channel-list@1.0.0:
@@ -8208,6 +8240,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symlink-or-copy@1.3.1: {}
@@ -8410,6 +8446,8 @@ snapshots:
       safe-regex: 1.1.0
 
   toidentifier@1.0.1: {}
+
+  tree-kill@1.2.2: {}
 
   tree-sync@1.4.0:
     dependencies:


### PR DESCRIPTION
prettier plugins will automatically run based on the presence of a package.json file.

so... if we have prettier installed (which it already was), we must configure CI to check it. Else editors will generate diff noise.