### PR TITLE
Use a default lang to improve default a11y

### DIFF
--- a/files/index.html
+++ b/files/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html<% if(lang) { %> lang="<%= lang %>"<% } %>>
+<html<% if(lang) { %> lang="<%= lang %>"<% } else { %> lang="en"<% } %>>
   <head>
     <meta charset="utf-8">
     <title><%= namespace %></title>


### PR DESCRIPTION
Considering this a bugfix, because every app needs a `lang` according to every html validator