### PR TITLE
Allow .env.test to be checked in to git

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -7,7 +7,8 @@
 /node_modules/
 
 # misc
-/.env*
+/.env
+/.env.*.local
 /.pnp*
 /.eslintcache
 /coverage/


### PR DESCRIPTION
In a new app, `.env.test` is git-ignored due to the previous git-ignore file containing `.env*`