### PR TITLE
Don't allow CI to run linting twice

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -33,7 +33,7 @@ Make use of the many generators for code, try `ember help generate` for more det
 ### Running Tests
 
 - `<%= invokeScriptPrefix %> test`
-- `<%= invokeScriptPrefix %> test:ember <% if (npm) { %>-- <% } %>--server`
+- `<%= invokeScriptPrefix %> test <% if (npm) { %>-- <% } %>--server`
 
 ### Linting
 

--- a/files/package.json
+++ b/files/package.json
@@ -24,8 +24,7 @@
     "lint:js:fix": "eslint . --fix<% if (typescript) { %>",
     "lint:types": "glint<% } %>",
     "start": "vite",
-    "test": "concurrently \"<%= packageManager %>:lint\" \"<%= packageManager %>:test:*\" --names \"lint,test:\" --prefixColors auto",
-    "test:ember": "vite build --mode development && testem ci"
+    "test": "vite build --mode development && testem ci"
   },
   "exports": {
     "./tests/*": "./tests/*",

--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -68,10 +68,10 @@ describe('basic functionality', function () {
         let result;
 
         try {
-          result = await project.execa('pnpm', ['test:ember']);
+          result = await project.execa('pnpm', ['test']);
         } catch (err) {
           console.log(err.stdout, err.stderr);
-          throw 'Failed to successfully run test:ember';
+          throw 'Failed to successfully run test';
         }
 
         // make sure that each of the tests that we expect actually show up


### PR DESCRIPTION
Linting is already a separate CI job.

When linting is part of `test` we:
- run it twice in CI (once for lint, once for test)
- have a harder time understanding logs in tests.

Since this is a new blueprint, we should not bring forward the mistakes of the past <3 