### PR TITLE
Revert "Prepare Stable Release v6.7.0"

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -2,17 +2,21 @@
   "solution": {
     "@ember/app-blueprint": {
       "impact": "minor",
-      "oldVersion": "6.6.0",
-      "newVersion": "6.7.0",
+      "oldVersion": "6.5.0",
+      "newVersion": "6.6.0",
       "tagName": "latest",
       "constraints": [
         {
           "impact": "minor",
           "reason": "Appears in changelog section :rocket: Enhancement"
+        },
+        {
+          "impact": "patch",
+          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./package.json"
     }
   },
-  "description": "## Release (2025-09-04)\n\n* @ember/app-blueprint 6.7.0 (minor)\n\n#### :rocket: Enhancement\n* `@ember/app-blueprint`\n  * [#65](https://github.com/ember-cli/ember-app-blueprint/pull/65) Update all dependencies for 6.7 release ([@mansona](https://github.com/mansona))\n\n#### Committers: 1\n- Chris Manson ([@mansona](https://github.com/mansona))\n"
+  "description": "## Release (2025-09-04)\n\n* @ember/app-blueprint 6.6.0 (minor)\n\n#### :rocket: Enhancement\n* `@ember/app-blueprint`\n  * [#63](https://github.com/ember-cli/ember-app-blueprint/pull/63) reset blueprint to match ember-cli app blueprint (in the next release) ([@mansona](https://github.com/mansona))\n  * [#57](https://github.com/ember-cli/ember-app-blueprint/pull/57) run update-blueprint-deps to update to Ember 6.6 ([@mansona](https://github.com/mansona))\n\n#### :house: Internal\n* `@ember/app-blueprint`\n  * [#60](https://github.com/ember-cli/ember-app-blueprint/pull/60) Split test files ([@pichfl](https://github.com/pichfl))\n\n#### Committers: 2\n- Chris Manson ([@mansona](https://github.com/mansona))\n- Florian Pichler ([@pichfl](https://github.com/pichfl))\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 ## Release (2025-09-04)
 
-* @ember/app-blueprint 6.7.0 (minor)
-
-#### :rocket: Enhancement
-* `@ember/app-blueprint`
-  * [#65](https://github.com/ember-cli/ember-app-blueprint/pull/65) Update all dependencies for 6.7 release ([@mansona](https://github.com/mansona))
-
-#### Committers: 1
-- Chris Manson ([@mansona](https://github.com/mansona))
-
-## Release (2025-09-04)
-
 * @ember/app-blueprint 6.6.0 (minor)
 
 #### :rocket: Enhancement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/app-blueprint",
-  "version": "6.7.0",
+  "version": "6.6.0",
   "description": "Blueprint for next generation of Ember apps",
   "keywords": [
     "ember-blueprint"


### PR DESCRIPTION
Reverts ember-cli/ember-app-blueprint#66

The release didn't actually go out so this is safe to do 👍 