### PR TITLE
Use strict mode for all CJS files

### DIFF
--- a/files/_js_babel.config.cjs
+++ b/files/_js_babel.config.cjs
@@ -1,3 +1,5 @@
+'use strict';
+
 const {
   babelCompatSupport,
   templateCompatSupport,

--- a/files/_ts_babel.config.cjs
+++ b/files/_ts_babel.config.cjs
@@ -1,3 +1,5 @@
+'use strict';
+
 const {
   babelCompatSupport,
   templateCompatSupport,


### PR DESCRIPTION
Other config files already had this, but babel.config.cjs was missing it.