### PR TITLE
Correct example usage command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ If you have an existing app that you would like to upgrade to use Vite consider 
 ## Usage
 
 ```
-pnpm dlx ember-cli@latest app my-app-name -b @ember/app-blueprint --pnpm
+pnpm dlx ember-cli@latest new my-app-name -b @ember/app-blueprint --pnpm
 ```


### PR DESCRIPTION
`ember app` seems to be an invalid ember-cli command, it should be `ember new`

Running the command that's currently in the README errors with:

```
The specified command app is invalid. For available options, see `ember help`.
```