### PR TITLE
Use TypeScript way of accessing potentially undefined `podModulePrefix`

### DIFF
--- a/files/app/config/environment.ts
+++ b/files/app/config/environment.ts
@@ -26,6 +26,7 @@ assert(
 
 export default config as {
   modulePrefix: string;
+  podModulePrefix?: string;
   locationType: string;
   rootURL: string;
   APP: Record<string, unknown>;


### PR DESCRIPTION
`podModulePrefix` is not part of the Record type for the environment config and TypeScript is weird about it. It should not be there in the first place but that's another story.

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).