### PR TITLE
update ember source to latest beta

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -80,7 +80,7 @@
     "ember-page-title": "^9.0.3",
     "ember-qunit": "^9.0.3",
     "ember-resolver": "^13.1.1",
-    "ember-source": "~6.8.0-beta.1",
+    "ember-source": "~6.8.0-beta.4",
     "ember-template-lint": "^7.9.3<% if (welcome) { %>",
     "ember-welcome-page": "^7.0.2<% } %>",
     "eslint": "^9.34.0",


### PR DESCRIPTION
I'm not exactly sure why https://github.com/ember-learn/super-rentals-tutorial/pull/272 isn't picking up the latest beta when there is a `~` dependency set up correctly 🤔 but when in doubt, force the update! 