### PR TITLE
[bugfix beta] fix the use of ember test in the new blueprint

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -24,7 +24,7 @@
     "lint:js:fix": "eslint . --fix<% if (typescript) { %>",
     "lint:types": "glint<% } %>",
     "start": "vite",
-    "test": "vite build --mode development && testem ci"
+    "test": "vite build --mode development && ember test --path dist"
   },
   "exports": {
     "./tests/*": "./tests/*",

--- a/files/testem.cjs
+++ b/files/testem.cjs
@@ -3,7 +3,6 @@
 if (typeof module !== 'undefined') {
   module.exports = {
     test_page: 'tests/index.html?hidepassed',
-    cwd: 'dist',
     disable_watching: true,
     launch_in_ci: ['Chrome'],
     launch_in_dev: ['Chrome'],


### PR DESCRIPTION
This fixes the use of `ember test` in the new Vite blueprint 🎉 We can't run testem directly until https://github.com/testem/testem/pull/1928 is fixed 👍 