### PR TITLE
[bugfix release] set node version in engines to >= 20

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -103,7 +103,7 @@
     "vite": "^7.1.9"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
in order to get #119 passing we need to set node version to 20