### PR TITLE
[bugfix release] Add eslint parser option `project: true`

### DIFF
--- a/files/_ts_eslint.config.mjs
+++ b/files/_ts_eslint.config.mjs
@@ -33,6 +33,7 @@ const parserOptions = {
     },
     ts: {
       projectService: true,
+      project: true,
       tsconfigRootDir: import.meta.dirname,
     },
   },


### PR DESCRIPTION
Today in apps the imports with `.gts` are working, but the eslint isn't working correctly, because in `ember-eslint-parser` we have a check, if `project` option is set [see](https://github.com/ember-tooling/ember-eslint-parser/blob/74b7345d3385d0c768ae96aa7d352bf3e9a72df7/src/parser/gjs-gts-parser.js#L162-L164)

Imports with extension are working without any issue and no lint error, when you are using in `<template>`-tag, but when the variable... is used in script-part you will get lint errors. 

Without `project: true`:
<img width="1864" height="273" alt="508682261-fe0f9a38-1c0b-4960-a408-a0a36e2e5bd0" src="https://github.com/user-attachments/assets/5e3f9728-0e33-4c27-98c6-141c1270d1ec" />

Wth `project: true`:
<img width="1639" height="273" alt="Image" src="https://github.com/user-attachments/assets/d391c55c-79ce-47c6-af2c-b0e467899f1b" />

This means, that when you have active `"allowImportingTsExtensions": true` (which is the default in `@ember/app-tsconfig`, landed in ember 6.8), you will run into this eslint issue and you can fix it only by removing extension (in this case you are loosing a vite performace improvement https://vite.dev/guide/performance.html#reduce-resolve-operations).

In addon-blueprint we have already added this option to get work `ember-eslint-parser` [see](https://github.com/ember-cli/ember-addon-blueprint/blob/173f0915e9a533de0cafeb312b851d19677a1ae7/files/eslint.config.mjs#L31)

Info about `parserOptions.project: true` you can find here: https://typescript-eslint.io/blog/parser-options-project-true/#introducing-true

To get more info about this bug, you can follow this issue: https://github.com/typed-ember/glint/issues/915

Note:
To see this issue not only in CI you need to add in `.vscode/settings.json` this snippet, otherwise the eslint in vscode is not active in `.gts`/`.gjs`.

```json
{
  "eslint.probe": [
    "javascript",
    "typescript",
    "html",
    "markdown",
    "json",
    "jsonc",
    "glimmer-js",
    "glimmer-ts"
   ],
  "eslint.validate": [
    "javascript",
    "typescript",
    "html",
    "markdown",
    "json",
    "jsonc",
    "glimmer-js",
    "glimmer-ts"
  ],
}
```

This is needed until `microsoft/vscode-eslint` package is updated to 3.0.19+ as release (today release is 3.0.16 and pre-release is 3.0.19)

https://github.com/microsoft/vscode-eslint/blob/pre-release/3.0.19/package.json#L329-L330