### PR TITLE
fix warpdrive lint tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
     "tmp-promise": "^3.0.3",
     "vitest": "^4.0.0-beta.17"
   },
-  "packageManager": "pnpm@10.7.0"
+  "packageManager": "pnpm@10.20.0"
 }

--- a/tests/warpdrive.test.mjs
+++ b/tests/warpdrive.test.mjs
@@ -126,7 +126,7 @@ describe('linting & formatting', function () {
     it('glint passes', async function () {
       expect(
         JSON.parse(app.files['package.json']).scripts['lint:types'],
-      ).to.equal('glint');
+      ).to.equal('ember-tsc --noEmit');
 
       let { exitCode, stdout } = await app.execa('pnpm', ['lint:types']);
 


### PR DESCRIPTION
It looks like https://github.com/ember-cli/ember-app-blueprint/pull/125 and https://github.com/ember-cli/ember-app-blueprint/pull/124 were merged a little bit too quickly and not tested together 🙈 

This PR makes the glint/ember-tsc check correct in the warpdrive test 👍 