### PR TITLE
Apply `typescript-eslint`'s recommended config to gts files

### DIFF
--- a/conditional-files/_ts_eslint.config.mjs
+++ b/conditional-files/_ts_eslint.config.mjs
@@ -77,7 +77,15 @@ export default defineConfig([
       parser: ember.parser,
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
+    extends: [
+      ...ts.configs.recommendedTypeChecked,
+      // https://github.com/ember-cli/ember-addon-blueprint/issues/119
+      {
+        ...ts.configs.eslintRecommended,
+        files: undefined,
+      },
+      ember.configs.gts,
+    ],
   },
   {
     files: ['tests/**/*-test.{js,gjs,ts,gts}'],

--- a/tests/fixtures/lint-ts/app/lint-test-gts.gts
+++ b/tests/fixtures/lint-ts/app/lint-test-gts.gts
@@ -1,0 +1,15 @@
+/**
+ * This file is used to ensure that `eslint.config.mjs` is properly configured
+ * to apply `typescript-eslint`'s recommended rules to `.gts` files. It ensures
+ * that:
+ *
+ * - `no-undef` is disabled (otherwise the undefined symbol would cause a
+ *   linting error)
+ * - `@typescript-eslint/no-unsafe-return` is enabled (otherwise the
+ *   `eslint-disable-next-line` comment would cause a linting error)
+ */
+export default function () {
+  // @ts-expect-error testing lint
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return notDefined;
+}

--- a/tests/fixtures/lint-ts/app/lint-test-ts.ts
+++ b/tests/fixtures/lint-ts/app/lint-test-ts.ts
@@ -1,0 +1,15 @@
+/**
+ * This file is used to ensure that `eslint.config.mjs` is properly configured
+ * to apply `typescript-eslint`'s recommended rules to `.ts` files. It ensures
+ * that:
+ *
+ * - `no-undef` is disabled (otherwise the undefined symbol would cause a
+ *   linting error)
+ * - `@typescript-eslint/no-unsafe-return` is enabled (otherwise the
+ *   `eslint-disable-next-line` comment would cause a linting error)
+ */
+export default function () {
+  // @ts-expect-error testing lint
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return notDefined;
+}

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -1,6 +1,7 @@
 import { beforeAll, describe, it, expect } from 'vitest';
 
 import { generateApp } from './helpers.mjs';
+import fixturify from 'fixturify';
 
 describe('linting & formatting', function () {
   describe('JavaScript', function () {
@@ -39,6 +40,11 @@ describe('linting & formatting', function () {
         flags: ['--typescript', '--pnpm'],
         skipNpm: false,
       });
+
+      fixturify.writeSync(
+        app.dir,
+        fixturify.readSync('./tests/fixtures/lint-ts'),
+      );
     });
 
     it('yields output without errors', async function (context) {


### PR DESCRIPTION
"Patch" `typescript-eslint`'s recommended config to allow us to extend it to `gts` files, and also add test cases to verify that we're applying the ruleset to both `ts` and `gts` files.

This is the equivalent of https://github.com/ember-cli/ember-addon-blueprint/pull/120 for this repo