### PR TITLE
Remove tracked-built-ins as it is now properly built-in 

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -88,8 +88,7 @@
     "qunit-dom": "^3.5.0",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^38.0.0",
-    "testem": "^3.17.0",
-    "tracked-built-ins": "^4.1.0<% if (typescript) { %>",
+    "testem": "^3.17.0<% if (typescript) { %>",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.50.1<% } %>",
     "vite": "^7.3.0"


### PR DESCRIPTION
Next: tracked-built-ins will have a notice on the README about being deprecated in new projects, but it's not problematic to use, and is built using public apis, so it'll likely work for a long time -- the exact way this messaging happens will need some thought from someone