### PR TITLE
[v6.10 backport] fix decorator-transforms runtime path in babel.config.mjs

### DIFF
--- a/conditional-files/_js_babel.config.mjs
+++ b/conditional-files/_js_babel.config.mjs
@@ -22,7 +22,9 @@ export default {
       'module:decorator-transforms',
       {
         runtime: {
-          import: import.meta.resolve('decorator-transforms/runtime-esm'),
+          import: fileURLToPath(
+            import.meta.resolve('decorator-transforms/runtime-esm'),
+          ),
         },
       },
     ],

--- a/conditional-files/_ts_babel.config.mjs
+++ b/conditional-files/_ts_babel.config.mjs
@@ -30,7 +30,9 @@ export default {
       'module:decorator-transforms',
       {
         runtime: {
-          import: import.meta.resolve('decorator-transforms/runtime-esm'),
+          import: fileURLToPath(
+            import.meta.resolve('decorator-transforms/runtime-esm'),
+          ),
         },
       },
     ],


### PR DESCRIPTION
This backports https://github.com/ember-cli/ember-app-blueprint/pull/226 to v6.10