### PR TITLE
Reset version because of failed release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,5 @@
 # Changelog
 
-## Release (2026-04-03)
-
-* @ember/app-blueprint 6.12.0 (minor)
-
-#### :rocket: Enhancement
-* `@ember/app-blueprint`
-  * [#243](https://github.com/ember-cli/ember-app-blueprint/pull/243) Promote Beta and update all dependencies for 6.12 release ([@mansona](https://github.com/mansona))
-  * [#144](https://github.com/ember-cli/ember-app-blueprint/pull/144) feat: move ember-cli-build to `mjs` ([@aklkv](https://github.com/aklkv))
-
-#### :bug: Bug Fix
-* `@ember/app-blueprint`
-  * [#215](https://github.com/ember-cli/ember-app-blueprint/pull/215) upgrade ember/optional-features to clear install deprecation warnings ([@void-mAlex](https://github.com/void-mAlex))
-  * [#119](https://github.com/ember-cli/ember-app-blueprint/pull/119) fix: align linters with recent changes in classic app blueprint ([@aklkv](https://github.com/aklkv))
-  * [#208](https://github.com/ember-cli/ember-app-blueprint/pull/208) [Bugfix release] Add `globals.browser` to eslint config for TS files ([@mkszepp](https://github.com/mkszepp))
-
-#### :memo: Documentation
-* `@ember/app-blueprint`
-  * [#204](https://github.com/ember-cli/ember-app-blueprint/pull/204) Update Release.md ([@mansona](https://github.com/mansona))
-
-#### :house: Internal
-* `@ember/app-blueprint`
-  * [#244](https://github.com/ember-cli/ember-app-blueprint/pull/244) split tests into individual matrix jobs ([@mansona](https://github.com/mansona))
-  * [#228](https://github.com/ember-cli/ember-app-blueprint/pull/228) Enable patch publish ([@mansona](https://github.com/mansona))
-  * [#211](https://github.com/ember-cli/ember-app-blueprint/pull/211) fix release-plan alpha tag ([@mansona](https://github.com/mansona))
-
-#### Committers: 4
-- Alex ([@void-mAlex](https://github.com/void-mAlex))
-- Alexey Kulakov ([@aklkv](https://github.com/aklkv))
-- Chris Manson ([@mansona](https://github.com/mansona))
-- Markus Sanin ([@mkszepp](https://github.com/mkszepp))
-
 ## Release (2026-03-03)
 
 * @ember/app-blueprint 6.11.2 (patch)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/app-blueprint",
-  "version": "6.12.0",
+  "version": "6.11.2",
   "description": "Blueprint for next generation of Ember apps",
   "keywords": [
     "ember-blueprint"


### PR DESCRIPTION
npm updating itself is failing right now because of an upstream issue: https://github.com/npm/cli/issues/9151

I'm going to fix it in a follow up PR but I am resetting the versions before I do 👍 