### PR TITLE
update node for Publish CI to a version that doesn't need to update npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
-      - run: npm install -g npm@latest # ensure that the globally installed npm is new enough to support OIDC
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
         # pass --github-prerelease when we are only branch other than release


### PR DESCRIPTION
we only updated npm to get a version that supported OIDC. We get that by default if we use Node 24