### PR TITLE
update typescript to v6

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -36,7 +36,7 @@
     "@babel/plugin-transform-runtime": "^7.29.0<% if (typescript) { %>",
     "@babel/plugin-transform-typescript": "^7.28.6<% } %>",
     "@babel/eslint-parser": "^7.28.6<% if (typescript) { %>",
-    "@ember/app-tsconfig": "^1.0.3<% } %>",
+    "@ember/app-tsconfig": "^2.0.0<% } %>",
     "@ember/optional-features": "^3.0.0",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.1",
@@ -89,7 +89,7 @@
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^38.0.0",
     "testem": "^3.20.0<% if (typescript) { %>",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2<% } %>",
     "vite": "^7.3.2"
   },


### PR DESCRIPTION
@ember-cli/tooling-core-team do we think that CI is adequate here to know if this TS version update is actually passing properly? 🤔 I know we do have typechecks but I don't know what the expected failures might be for TS v6