### PR TITLE
Enable Glint by default for both JS and TS apps

### DIFF
--- a/files/jsconfig.json
+++ b/files/jsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@ember/app-tsconfig",
+  "include": ["app", "tests", "types"],
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "paths": {
+      "<%= name %>/tests/*": ["./tests/*"],
+      "<%= name %>/*": ["./app/*"],
+      "*": ["./types/*"]
+    },
+    "types": [
+      "ember-source/types",
+      "@embroider/core/virtual",
+      "vite/client",
+      "@glint/ember-tsc/types"
+    ]
+  }
+}

--- a/files/package.json
+++ b/files/package.json
@@ -35,8 +35,8 @@
     "@babel/runtime": "^7.29.2",
     "@babel/plugin-transform-runtime": "^7.29.0<% if (typescript) { %>",
     "@babel/plugin-transform-typescript": "^7.28.6<% } %>",
-    "@babel/eslint-parser": "^7.28.6<% if (typescript) { %>",
-    "@ember/app-tsconfig": "^2.0.0<% } %>",
+    "@babel/eslint-parser": "^7.28.6",
+    "@ember/app-tsconfig": "^2.0.0",
     "@ember/optional-features": "^3.0.0",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.1",
@@ -49,10 +49,10 @@
     "@embroider/config-meta-loader": "^1.0.0",
     "@embroider/legacy-inspector-support": "^0.1.3",
     "@eslint/js": "^9.39.4",
-    "@glimmer/component": "^2.1.1<% if (typescript) { %>",
+    "@glimmer/component": "^2.1.1",
     "@glint/ember-tsc": "^1.5.0",
     "@glint/template": "^1.7.7",
-    "@glint/tsserver-plugin": "^2.4.0<% } %>",
+    "@glint/tsserver-plugin": "^2.4.0",
     "@rollup/plugin-babel": "^7.0.0<% if (typescript) { %>",
     "@types/qunit": "^2.19.13",
     "@types/rsvp": "^4.0.9<% } %><% if (warpDrive) { %>",
@@ -88,9 +88,9 @@
     "qunit-dom": "^3.5.1",
     "stylelint": "^17.8.0",
     "stylelint-config-standard": "^40.0.0",
-    "testem": "^3.20.0<% if (typescript) { %>",
-    "typescript": "^6.0.3",
-    "typescript-eslint": "^8.58.2<% } %>",
+    "testem": "^3.20.0",
+    "typescript": "^6.0.3",<% if (typescript) { %>
+    "typescript-eslint": "^8.58.2",<% } %>
     "vite": "^8.0.9"
   },
   "engines": {

--- a/index.js
+++ b/index.js
@@ -148,12 +148,14 @@ module.exports = {
         (file) =>
           file !== 'tsconfig.json' &&
           file !== 'app/config/environment.ts' &&
-          !file.startsWith('types/') &&
           !file.endsWith('.d.ts'),
       );
     } else {
       // For TypeScript apps, exclude the JS version of app/config/environment
-      files = files.filter((file) => file !== 'app/config/environment.js');
+      // and the JS-only jsconfig.json.
+      files = files.filter(
+        (file) => file !== 'app/config/environment.js' && file !== 'jsconfig.json',
+      );
     }
 
     const warpDrive = options.warpDrive || options.emberData;

--- a/index.js
+++ b/index.js
@@ -154,7 +154,8 @@ module.exports = {
       // For TypeScript apps, exclude the JS version of app/config/environment
       // and the JS-only jsconfig.json.
       files = files.filter(
-        (file) => file !== 'app/config/environment.js' && file !== 'jsconfig.json',
+        (file) =>
+          file !== 'app/config/environment.js' && file !== 'jsconfig.json',
       );
     }
 


### PR DESCRIPTION
## Summary

Implements [RFC #976: Enable Glint by Default](https://github.com/emberjs/rfcs/pull/976) for the app blueprint. Glint v2 is now installed and configured for both TS and JS apps.

The blueprint already shipped Glint v2 packages — this PR moves them out of the \`<% if (typescript) %>\` blocks so JS apps benefit from editor tooling out of the box.

- TS path: \`tsconfig.json\` and the existing \`lint:types: ember-tsc --noEmit\` script — unchanged.
- JS path: a new \`jsconfig.json\` (not \`tsconfig.json\`) that signals "IDE tooling only, no CLI type-check." Glint deps are installed for editor support; no \`lint:types\` script is added.
- \`@glint/ember-tsc\`, \`@glint/template\`, \`@glint/tsserver-plugin\`, \`@ember/app-tsconfig\`, and \`typescript\` move out of the TS-only conditional in \`package.json\`.
- The previous \`!file.startsWith('types/')\` filter for JS apps is dropped — both jsconfig.json and tsconfig.json reference \`types/\`, and the dir doesn't currently contain blueprint-shipped files.
- \`index.js\` filters \`jsconfig.json\` out of TS apps, symmetric to the existing \`tsconfig.json\` filter for JS apps.

## Related

- RFC: emberjs/rfcs#976
- Companion change in upstream ember-cli (legacy app-blueprint inside the monorepo): ember-cli/ember-cli#11015
- Sibling addon-blueprint PR: ember-cli/ember-addon-blueprint (will link)
- Docs: ember-learn/guides-source#2211
- Announcement post: ember-learn/ember-blog#1373

## Test plan

- [ ] Generate a JS app: \`ember new my-app\` against this blueprint. Confirm \`jsconfig.json\` present, no \`tsconfig.json\`, Glint v2 packages installed.
- [ ] Generate a TS app: \`ember new my-app --typescript\`. Confirm \`tsconfig.json\` present, no \`jsconfig.json\`, \`lint:types: ember-tsc --noEmit\` works.
- [ ] CI: existing blueprint tests pass.

## Note on archived predecessor

The earlier \`embroider-build/app-blueprint\` is archived; this PR is the same set of changes adapted for the new structure here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)