### PR TITLE
Fix an issue with the `--no-warp-drive` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,13 @@ module.exports = {
     let name = stringUtil.dasherize(rawName);
     let namespace = stringUtil.classify(rawName);
 
+    const warpDrive = options.warpDrive ?? options.emberData;
+
     let hasOptions =
-      !options.welcome || options.packageManager || options.ciProvider;
+      !options.welcome ||
+      options.packageManager ||
+      options.ciProvider ||
+      !warpDrive;
     let blueprintOptions = '';
     if (hasOptions) {
       let indent = `\n            `;
@@ -80,8 +85,7 @@ module.exports = {
           options.packageManager === 'pnpm' && '"--pnpm"',
           options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
           options.typescript && `"--typescript"`,
-          !options.emberData && `"--no-ember-data"`,
-          !options.warpDrive && `"--no-warp-drive"`,
+          warpDrive === false && `"--no-warp-drive"`,
         ]
           .filter(Boolean)
           .join(',\n            ') +
@@ -117,7 +121,7 @@ module.exports = {
       blueprint: 'app',
       blueprintOptions,
       lang: options.lang,
-      warpDrive: options.warpDrive ?? options.emberData,
+      warpDrive,
       ciProvider: options.ciProvider,
       typescript: options.typescript,
       packageManager: options.packageManager ?? 'npm',

--- a/tests/arguments.test.mjs
+++ b/tests/arguments.test.mjs
@@ -126,6 +126,12 @@ describe('Blueprint Arguments', function () {
 
       expect(parse(files['package.json']).devDependencies['@warp-drive/core'])
         .to.not.be.undefined;
+
+      expect(
+        parse(files.config['ember-cli-update.json'])
+          .packages.at(0)
+          .blueprints.at(0).options,
+      ).to.not.include('--no-warp-drive');
     });
 
     it('does not add warp-drive if you pass --no-warp-drive', async function () {
@@ -133,6 +139,12 @@ describe('Blueprint Arguments', function () {
 
       expect(parse(files['package.json']).devDependencies['@warp-drive/core'])
         .to.be.undefined;
+
+      expect(
+        parse(files.config['ember-cli-update.json'])
+          .packages.at(0)
+          .blueprints.at(0).options,
+      ).to.include('--no-warp-drive');
     });
   });
 


### PR DESCRIPTION
This prevents the option from being added to the `ember-cli-update.json` file if the option is not passed.

Backport of #272 to the release branch.