### PR TITLE
refactor: remove sort-package-json dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const stringUtil = require('ember-cli-string-utils');
 const { styleText } = require('node:util');
 const directoryForPackageName = require('./lib/directory-for-package-name');
-const { sortPackageJson } = require('sort-package-json');
 const { join } = require('path');
 const { readFileSync } = require('fs');
 const ejs = require('ejs');
@@ -192,9 +191,9 @@ module.exports = {
     return fileInfo;
   },
 
-  updatePackageJson(options, content) {
+  updatePackageJson(_options, content) {
     let contents = JSON.parse(content);
 
-    return stringifyAndNormalize(sortPackageJson(contents));
+    return stringifyAndNormalize(contents);
   },
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ejs": "^3.1.10",
     "ember-cli-string-utils": "^1.1.0",
     "lodash": "^4.18.1",
-    "sort-package-json": "^3.7.1",
     "walk-sync": "^4.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
-      sort-package-json:
-        specifier: ^3.7.1
-        version: 3.7.1
       walk-sync:
         specifier: ^4.0.2
         version: 4.0.2

--- a/tests/package-json.test.mjs
+++ b/tests/package-json.test.mjs
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sortedCopy(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortedCopy);
+  }
+
+  if (isObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, sortedCopy(value[key])]),
+    );
+  }
+
+  return value;
+}
+
+describe('package.json template', function () {
+  it('is sorted', function () {
+    let packageJsonPath = join(__dirname, '..', 'files', 'package.json');
+    let packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+    expect(packageJson).toEqual(sortedCopy(packageJson));
+  });
+});


### PR DESCRIPTION
- Remove sortPackageJson usage in updatePackageJson
- Drop sort-package-json from dependencies
- Add tests for package.json update behavior

Fixes ember-cli/ember-app-blueprint#268