### PR TITLE
fix release-plan plan CI

### DIFF
--- a/.github/workflows/plan-alpha-release.yml
+++ b/.github/workflows/plan-alpha-release.yml
@@ -40,6 +40,8 @@ jobs:
         name: Run release-plan prepare
         with:
           ref: 'main'
+        env:
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
         id: explanation
 
       - uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
I made a little mistake in https://github.com/ember-cli/ember-app-blueprint/pull/295/changes/f35ca9a839bf65d09087852a1245047789d68ebf

I wanted PRs to not be opened by "Me" but I think that's actually a problem on ember-cli and not on ember-app-blueprint 🤦 

