### PR TITLE
Fix prettier failure in testem.cjs (single quotes for cwd)

### DIFF
--- a/files/testem.cjs
+++ b/files/testem.cjs
@@ -3,7 +3,7 @@
 if (typeof module !== 'undefined') {
   module.exports = {
     test_page: 'tests/index.html?hidepassed',
-    cwd: "dist",
+    cwd: 'dist',
     disable_watching: true,
     launch_in_ci: ['Chrome'],
     launch_in_dev: ['Chrome'],


### PR DESCRIPTION
Fixes the failing `linting & formatting` jobs on #307.

The generated app's prettier config sets `singleQuote: true`, so the double-quoted `cwd: "dist"` added in #307 failed `prettier --check` in both `tests/lint.test.mjs` and `tests/warpdrive.test.mjs`. This switches it to single quotes.

Verified locally: both previously-failing `linting & formatting` test runs now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)